### PR TITLE
Add bintray publishing of artifact

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,10 @@ plugins {
     id 'java'
     id 'com.github.johnrengelman.shadow' version '1.2.1'
     id 'pmd'
+    id 'com.jfrog.bintray' version '1.1'
 }
 
-version = '1.0.0-SNAPSHOT'
+version = '1.0.0'
 group = 'com.lookout.cassandra'
 defaultTasks 'check', 'assemble'
 
@@ -44,6 +45,24 @@ dependencies {
     testCompile group: 'io.netty', name: 'netty-all', version: '4.0.27.Final'
     testCompile group: 'com.google.collections', name: 'google-collections', version: '1.0'
     testCompile group: 'junit', name: 'junit', version: '4.11'
+}
+
+bintray {
+  filesSpec {
+    from 'build/libs'
+    into '.'
+  }
+  publish = true
+  pkg {
+    repo = 'systems'
+    name = 'cassandra-health-check'
+    user = project.hasProperty('bintrayUser') ? project.bintrayUser : System.getenv('BINTRAY_USER')
+    key = project.hasProperty('bintrayApiKey') ? project.bintrayApiKey : System.getenv('BINTRAY_KEY')
+    userOrg = 'lookout'
+    version {
+        name = project.version
+    }
+  }
 }
 
 pmd {


### PR DESCRIPTION
This also changes the release number to 1.0.0 for the initial release.
We probably need some better way to manage the release number.